### PR TITLE
serverless peer dependency set up to serverless 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "sinon": "^14.0.0"
   },
   "peerDependencies": {
-    "serverless": "2.x"
+    "serverless": ">= 2.x <= 3.21.x"
   },
   "engines": {
     "node": ">=12.0"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "sinon": "^14.0.0"
   },
   "peerDependencies": {
-    "serverless": ">= 2.x <= 3.21.x"
+    "serverless": ">= 2.x < 4.x"
   },
   "engines": {
     "node": ">=12.0"


### PR DESCRIPTION
We're in the process of updating our services to use serverless 3. One of our services, activity search, is using the for each serverless plugin. We're hoping to update this plugin to be compatible with serverless 3.