### PR TITLE
chore: update-package-lock workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     directory: "/"
     schedule:
       interval: monthly
-    versioning-strategy: increase
+    versioning-strategy: increase-if-necessary
     commit-message:
       prefix: fix
       prefix-development: build
@@ -13,5 +13,9 @@ updates:
     ignore:
       - dependency-name: "chai"
         versions: [">=5.0"] # ESM only
+      # update-package-lock workflow already handles most minor/patch updates
+      # continue checking minor updates to cover dependendencies with version pattern 0.*.*
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
     reviewers:
       - "Brightspace/lurvig"

--- a/.github/workflows/update-package-lock.yml
+++ b/.github/workflows/update-package-lock.yml
@@ -1,0 +1,12 @@
+name: Update package-lock.json
+on:
+  schedule:
+    - cron: '0 15 * * 1' # Mon 11:00AM EDT. 10:00AM EST.
+    - cron: '0 6 1 * *' # 1st of each month 2:00 AM EDT/1:00 AM EST
+  workflow_dispatch: # manual trigger
+jobs:
+  Update:
+    uses: Brightspace/space-github-actions/.github/workflows/update-package-lock.yml@main
+    secrets: inherit
+    with:
+      DEFAULT_BRANCH: master

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
 * @Brightspace/lurvig
+package-lock.json


### PR DESCRIPTION
[US160955](https://rally1.rallydev.com/#/?detail=/userstory/732729726349&fdp=true)

 

- [x] A special token is added in repo-settings
- [x]  Repo has auto merges and squash merges enabled
- [x]  Repo has required CI checks configured
- [x] Dependabot is configured to ignore patch version updates
- [x]  Dependabot versioning strategy is set to increase-if-necessary
- [x] The update workflow is scheduled to run every Monday and on the 1st of the month
- [x]  Remove CODEOWNERS for the package-lock.json