### PR TITLE
GAUD-292 - Use new release token

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,6 +64,6 @@ jobs:
         uses: BrightspaceUI/actions/semantic-release@main
         with:
           DEFAULT_BRANCH: master
-          GITHUB_TOKEN: ${{ secrets.D2L_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.D2L_RELEASE_TOKEN }}
           NPM: true
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
The `brightspace-bot` and `D2L_GITHUB_TOKEN` are no longer needed for `release` workflows. Instead, we have a [new `D2L_RELEASE_TOKEN`](https://github.com/Brightspace/repo-settings/blob/main/docs/release_action_setup.md) that has the ability to bypass the repo ruleset (configured in https://github.com/Brightspace/repo-settings/pull/1602) and org-level ruleset.

Before merging, I will:
- Confirm the new ruleset matches the old branch protection rule before deleting it
- Remove `brightspace-bot` as a repo contributor
- Confirm the `D2L_RELEASE_TOKEN` is available and remove this repo's access to `D2L_GITHUB_TOKEN`

If you need to make a cert or hotfix, this will need to be backported to the `20.24.02` and `20.24.01` release branches.