### PR TITLE
chore(deps): replace lodash.get and lodash.set by lodash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.12.0",
-        "lodash.get": "^4.4.2",
-        "lodash.set": "^4.3.2"
+        "lodash": "^4.17.21"
       },
       "devDependencies": {
         "chai": "^4.3.10",
@@ -7529,11 +7528,6 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
-    },
-    "node_modules/lodash.set": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-      "integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg=="
     },
     "node_modules/lodash.union": {
       "version": "4.6.0",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
   },
   "dependencies": {
     "ajv": "^8.12.0",
-    "lodash.get": "^4.4.2",
-    "lodash.set": "^4.3.2"
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "chai": "^4.3.10",

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
 'use strict';
 
 const Ajv = require('ajv');
-const get = require('lodash.get');
-const set = require('lodash.set');
+const get = require('lodash/get');
+const set = require('lodash/set');
 
 const EXCLUDE_PATHS = new Set([
 	'serverless', 'serviceObject', 'pluginsData', 'package',


### PR DESCRIPTION
Replace lodash.get and lodash.set by lodash which hasn't been updated in 8 years.

Actually, lodash.set has a high vulnerability and it must be fixed as soon as possible : 

```
# npm audit report

lodash.set  *
Severity: high
Prototype Pollution in lodash - https://github.com/advisories/GHSA-p6mc-m468-83gw
No fix available
node_modules/lodash.set
  serverless-plugin-for-each  *
  Depends on vulnerable versions of lodash.set
  node_modules/serverless-plugin-for-each

2 high severity vulnerabilities
```

This issue close #112 