### PR TITLE
chore: Test on Node 20

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 2
     strategy:
       matrix:
-        node: [18]
+        node: [18, 20]
     steps:
       - name: Checkout
         uses: Brightspace/third-party-actions@actions/checkout


### PR DESCRIPTION
[LURV-1665](https://desire2learn.atlassian.net/browse/LURV-1665)

This repo does not use library-ci. It was already on Node 18 but was not testing for Node 20 so this PR adds support for Node 20.

[LURV-1665]: https://desire2learn.atlassian.net/browse/LURV-1665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ