### PR TITLE
add publishConfig.registry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
   "contributors": [
     "Anton Bazhal <am.bazhal@gmail.com> (https://github.com/AntonBazhal)"
   ],
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  },
   "nyc": {
     "include": [
       "src/**"


### PR DESCRIPTION
Needed to publish to public NPM while reading packages from our proxy registry

HOD-4564