### PR TITLE
chore: enable package-lock Slack notifications

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,6 @@ updates:
         versions: [">=2.0"] # Requires eslint >= 9
       - dependency-name: "eslint-plugin-mocha"
         versions: [">=11.0"] # ESM only
-      # update-package-lock workflow already handles most minor/patch updates
-      # continue checking minor updates to cover dependendencies with version pattern 0.*.*
+      # update-package-lock workflow handles minor and patch updates.
       - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
+        update-types: ["version-update:semver-patch", "version-update:semver-minor"]

--- a/.github/workflows/update-package-lock.yml
+++ b/.github/workflows/update-package-lock.yml
@@ -26,3 +26,6 @@ jobs:
           APPROVAL_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BRANCH: master
           GITHUB_TOKEN: ${{ secrets.DEPENDENCIES_TOKEN }}
+          SLACK_CHANNEL_FAILURE: '#buccaneer-alerts'
+          SLACK_CHANNEL_STALE_PR: '#buccaneer-alerts'
+          SLACK_TOKEN: ${{ secrets.D2L_SLACK_TOKEN }}


### PR DESCRIPTION
## Summary

- Send update-package-lock failure notifications to `#buccaneer-alerts`.
- Send stale update-package-lock PR notifications to `#buccaneer-alerts`.
- Provide the registered `D2L_SLACK_TOKEN` to the update action.
- Ignore ordinary Dependabot patch and minor updates so the scheduled package-lock workflow handles them.

## Validation

- Parsed `.github/workflows/update-package-lock.yml` and `.github/dependabot.yml` successfully.
- Verified the wildcard Dependabot rule ignores patch and minor updates.
- Ran `git diff --check`.

Jira: https://desire2learn.atlassian.net/browse/BUC-7608